### PR TITLE
fix: do not automatically try to deploy to prod

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -39,37 +39,3 @@ jobs:
     uses: ./.github/workflows/.tests.yml
     with:
       target: test
-
-  deploy-prod:
-    name: Deploy (PROD)
-    needs: [tests]
-    uses: ./.github/workflows/.deployer.yml
-    secrets: inherit
-    with:
-      environment: prod
-      db_user: appproxy # appproxy is the user which works with pgbouncer.
-      params:
-        --set backend.deploymentStrategy=RollingUpdate
-        --set frontend.deploymentStrategy=RollingUpdate
-        --set global.autoscaling=true
-        --set frontend.pdb.enabled=true
-        --set backend.pdb.enabled=true
-      tag: ${{ inputs.tag }}
-
-  promote:
-    name: Promote Images
-    needs: [deploy-prod]
-    runs-on: ubuntu-24.04
-    permissions:
-      packages: write
-    strategy:
-      matrix:
-        package: [migrations, backend, frontend]
-    timeout-minutes: 1
-    steps:
-      - uses: shrink/actions-docker-registry-tag@f04afd0559f66b288586792eb150f45136a927fa # v4
-        with:
-          registry: ghcr.io
-          repository: ${{ github.repository }}/${{ matrix.package }}
-          target: ${{ needs.deploy-prod.outputs.tag }}
-          tags: prod


### PR DESCRIPTION
# Description

I forgot to remove the automatic deploy to prod. We decided that we will manually trigger this.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-ipm-platform-4-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-ipm-platform-4-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-ipm-platform/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-ipm-platform/actions/workflows/merge.yml)