### PR TITLE
fix: bring pvc requests under quota

### DIFF
--- a/charts/crunchy/values.yml
+++ b/charts/crunchy/values.yml
@@ -35,7 +35,7 @@ crunchy:
     dataVolumeClaimSpec:
       storage: 150Mi
       storageClassName: netapp-block-standard
-      walStorage: 600Mi
+      walStorage: 300Mi
 
     requests:
       cpu: 50m


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

The test environment has a quota of 1Gi for our database storage, which is 100% utilized when the db backups are configured to use 600Mi. Since we need two of these claims I'm halving the request and hoping this doesn't cause storage errors later on.

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://nr-ipm-platform-5-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://nr-ipm-platform-5-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/nr-ipm-platform/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/nr-ipm-platform/actions/workflows/merge.yml)